### PR TITLE
Extensões linux e PHP

### DIFF
--- a/7.3/with-apache/Dockerfile
+++ b/7.3/with-apache/Dockerfile
@@ -7,7 +7,8 @@ ENV APACHE_RUN_GROUP php
 ENV APPLICATION \
     git \
     wget \
-    curl
+    curl \
+    unzip
 
 ENV PHP_DEPS \
     libpng-dev \
@@ -33,7 +34,8 @@ ENV EXTENSION \
     tokenizer \
     xsl \
     gd \
-    mbstring
+    mbstring \
+    pcntl
 
 RUN groupadd --gid 1000 php \
     && useradd --uid 1000 --gid php -m php
@@ -65,7 +67,7 @@ WORKDIR /home/php/app
 
 RUN a2enmod rewrite ssl \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
-    && chown php.php /home/php
+    && chown php.php -R /home/php
 
 USER php
 

--- a/7.3/with-apache/php.ini
+++ b/7.3/with-apache/php.ini
@@ -311,7 +311,7 @@ serialize_precision = -1
 ; This directive allows you to disable certain functions for security reasons.
 ; It receives a comma-delimited list of function names.
 ; http://php.net/disable-functions
-disable_functions = pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_get_handler,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,pcntl_async_signals,
+; disable_functions = pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_get_handler,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,pcntl_async_signals,
 
 ; This directive allows you to disable certain classes for security reasons.
 ; It receives a comma-delimited list of class names.


### PR DESCRIPTION
Foi instalado a extensão PCNTL para trabalhar com processo assíncrono no
php. Além da instalação foi necessário comentar a diretiva "disable_functions"
no php.init.

Foi instalado o pacote unzip no linux e uma permissão recursiva no
diretório /home/php .

Resolvido: #instalacao-pacotes.